### PR TITLE
Detect dynamic imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ module.exports.isREMForm = function(node) {
 
 module.exports.isES6Import = function(node) {
   switch(node.type) {
+    case 'Import':
     case 'ImportDeclaration':
     case 'ImportDefaultSpecifier':
     case 'ImportNamespaceSpecifier':

--- a/test/test.js
+++ b/test/test.js
@@ -105,6 +105,7 @@ describe('module-types', function() {
       assert(check('import * as foo from "mod.js";', types.isES6Import, true));
       assert(check('import "mylib2";', types.isES6Import, true));
       assert(check('import foo from "mod.js";', types.isES6Import, true));
+      assert(check('import("foo");', types.isES6Import, true));
     });
 
     it('detects es6 exports', function () {


### PR DESCRIPTION
While looking into this [issue](https://github.com/dependents/node-precinct/issues/60) in precinct I figured out that it is node-ast-module-types that does not detect a script as an es6 module if it contains a dynamic import but no exports or other imports. I extended the isES6Import function to return true when it encounters a dynamic import. The definition for dynamic imports  in ESTree can be found here https://github.com/estree/estree/blob/master/experimental/import-expression.md